### PR TITLE
SYS-628 handle positional args and kwargs properly in Ruby 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.2
+
+Utilize [Ruby 3 argument forwarding](https://blog.saeloun.com/2020/09/16/ruby-3-0-to-add-support-for-forwarding-arguments-along-with-lead-arguments/#after) in method_missing
+
+
+## 0.1
+
+Initial version

--- a/db_schema_change_warning.gemspec
+++ b/db_schema_change_warning.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "db_schema_change_warning"
-  s.version     = "0.1"
+  s.version     = "0.2"
   s.summary     = "Output warnings when a new Rails migration is run in development mode."
   s.description = "Output warnings when a new Rails migration is run in development mode."
   s.authors     = ["Florent Guilleux"]
@@ -8,4 +8,5 @@ Gem::Specification.new do |s|
   s.files       = Dir.glob("lib/**/*", File::FNM_DOTMATCH)
   s.homepage    = "https://github.com/intellum/db-schema-change-warning"
   s.license     = "MIT"
+  s.required_ruby_version = '>= 3.0.6'
 end

--- a/lib/db_schema_change_warning.rb
+++ b/lib/db_schema_change_warning.rb
@@ -27,7 +27,7 @@ module DbSchemaChangeWarning
     end
   end
 
-  def method_missing(method, *args) # Executed when a migration methods runs, e.g. add_column.
+  def method_missing(method, ...) # Executed when a migration methods runs, e.g. add_column.
     @warn = true if method.in?(WARNING_OPERATIONS)
     super
   end


### PR DESCRIPTION
https://intellum.atlassian.net/browse/SYS-628

Gives an error about too many arguments otherwise:

```
D, [2023-11-09T10:48:30.075628 #72635] DEBUG -- : using default configuration
Server started at: 2023-11-09T10:48:34-06:00
== 20231109132431 TestMigrationTwo: reverting =================================
-- remove_column(:testsessions, :test_column, :string, {:default=>"def"})
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

wrong number of arguments (given 4, expected 2..3)
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/connection_adapters/abstract/schema_statements.rb:651:in `remove_column'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:929:in `block in method_missing'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:897:in `block in say_with_time'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:897:in `say_with_time'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:918:in `method_missing'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/strong_migrations-0.8.0/lib/strong_migrations/migration.rb:16:in `block in method_missing'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/strong_migrations-0.8.0/lib/strong_migrations/checker.rb:322:in `perform'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/strong_migrations-0.8.0/lib/strong_migrations/migration.rb:15:in `method_missing'
/Users/danb/code/intellum/exceed/config/initializers/verify_database_columns_being_removed_have_been_ignored.rb:49:in `method_missing'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/bundler/gems/db-schema-change-warning-00349723a9b8/lib/db_schema_change_warning.rb:32:in `method_missing'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration/command_recorder.rb:126:in `block in replay'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration/command_recorder.rb:125:in `each'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration/command_recorder.rb:125:in `replay'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:741:in `revert'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:865:in `exec_migration'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:851:in `block (2 levels) in migrate'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:850:in `block in migrate'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/connection_adapters/abstract/connection_pool.rb:462:in `with_connection'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:849:in `migrate'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/strong_migrations-0.8.0/lib/strong_migrations/migration.rb:5:in `migrate'
/Users/danb/code/intellum/exceed/config/initializers/verify_database_columns_being_removed_have_been_ignored.rb:11:in `migrate'
/Users/danb/code/intellum/exceed/config/initializers/verify_database_migrations_do_not_perform_bulk_sql_operations.rb:24:in `migrate'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/bundler/gems/db-schema-change-warning-00349723a9b8/lib/db_schema_change_warning.rb:9:in `migrate'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1037:in `migrate'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1329:in `block in execute_migration_in_transaction'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1380:in `block in ddl_transaction'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/connection_adapters/abstract/database_statements.rb:320:in `block in transaction'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/connection_adapters/abstract/transaction.rb:319:in `block in within_new_transaction'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activesupport-6.1.7.6/lib/active_support/concurrency/load_interlock_aware_monitor.rb:26:in `block (2 levels) in synchronize'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activesupport-6.1.7.6/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activesupport-6.1.7.6/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activesupport-6.1.7.6/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activesupport-6.1.7.6/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/connection_adapters/abstract/transaction.rb:317:in `within_new_transaction'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/connection_adapters/abstract/database_statements.rb:320:in `transaction'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/transactions.rb:209:in `transaction'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1380:in `ddl_transaction'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1328:in `execute_migration_in_transaction'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1302:in `each'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1302:in `migrate_without_lock'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1251:in `block in migrate'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1401:in `block in with_advisory_lock'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1416:in `block in with_advisory_lock_connection'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/connection_adapters/abstract/connection_pool.rb:462:in `with_connection'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1416:in `with_advisory_lock_connection'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1397:in `with_advisory_lock'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1251:in `migrate'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1096:in `down'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1203:in `public_send'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1203:in `move'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1072:in `rollback'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/railties/databases.rake:281:in `block (2 levels) in <top (required)>'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/bin/bundle:25:in `load'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/bin/bundle:25:in `<main>'

Caused by:
ArgumentError: wrong number of arguments (given 4, expected 2..3)
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/connection_adapters/abstract/schema_statements.rb:651:in `remove_column'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:929:in `block in method_missing'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:897:in `block in say_with_time'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:897:in `say_with_time'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:918:in `method_missing'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/strong_migrations-0.8.0/lib/strong_migrations/migration.rb:16:in `block in method_missing'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/strong_migrations-0.8.0/lib/strong_migrations/checker.rb:322:in `perform'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/strong_migrations-0.8.0/lib/strong_migrations/migration.rb:15:in `method_missing'
/Users/danb/code/intellum/exceed/config/initializers/verify_database_columns_being_removed_have_been_ignored.rb:49:in `method_missing'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/bundler/gems/db-schema-change-warning-00349723a9b8/lib/db_schema_change_warning.rb:32:in `method_missing'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration/command_recorder.rb:126:in `block in replay'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration/command_recorder.rb:125:in `each'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration/command_recorder.rb:125:in `replay'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:741:in `revert'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:865:in `exec_migration'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:851:in `block (2 levels) in migrate'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:850:in `block in migrate'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/connection_adapters/abstract/connection_pool.rb:462:in `with_connection'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:849:in `migrate'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/strong_migrations-0.8.0/lib/strong_migrations/migration.rb:5:in `migrate'
/Users/danb/code/intellum/exceed/config/initializers/verify_database_columns_being_removed_have_been_ignored.rb:11:in `migrate'
/Users/danb/code/intellum/exceed/config/initializers/verify_database_migrations_do_not_perform_bulk_sql_operations.rb:24:in `migrate'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/bundler/gems/db-schema-change-warning-00349723a9b8/lib/db_schema_change_warning.rb:9:in `migrate'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1037:in `migrate'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1329:in `block in execute_migration_in_transaction'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1380:in `block in ddl_transaction'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/connection_adapters/abstract/database_statements.rb:320:in `block in transaction'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/connection_adapters/abstract/transaction.rb:319:in `block in within_new_transaction'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activesupport-6.1.7.6/lib/active_support/concurrency/load_interlock_aware_monitor.rb:26:in `block (2 levels) in synchronize'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activesupport-6.1.7.6/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activesupport-6.1.7.6/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activesupport-6.1.7.6/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activesupport-6.1.7.6/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/connection_adapters/abstract/transaction.rb:317:in `within_new_transaction'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/connection_adapters/abstract/database_statements.rb:320:in `transaction'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/transactions.rb:209:in `transaction'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1380:in `ddl_transaction'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1328:in `execute_migration_in_transaction'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1302:in `each'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1302:in `migrate_without_lock'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1251:in `block in migrate'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1401:in `block in with_advisory_lock'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1416:in `block in with_advisory_lock_connection'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/connection_adapters/abstract/connection_pool.rb:462:in `with_connection'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1416:in `with_advisory_lock_connection'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1397:in `with_advisory_lock'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1251:in `migrate'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1096:in `down'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1203:in `public_send'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1203:in `move'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/migration.rb:1072:in `rollback'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/activerecord-6.1.7.6/lib/active_record/railties/databases.rake:281:in `block (2 levels) in <top (required)>'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/bin/bundle:25:in `load'
/Users/danb/.rvm/gems/ruby-3.0.6@exceedlms/bin/bundle:25:in `<main>'
Tasks: TOP => db:rollback
(See full trace by running task with --trace)
```